### PR TITLE
feat: IsValidTeamVictory

### DIFF
--- a/addons/sourcemod/scripting/include/loghelper.inc
+++ b/addons/sourcemod/scripting/include/loghelper.inc
@@ -1,4 +1,4 @@
-#define LOGHELPER_VERSION 3
+#define LOGHELPER_VERSION 4
 
 #include <sourcemod>
 #include <sdktools>
@@ -197,4 +197,21 @@ stock bool IsValidPlayer(int client)
 		return true;
 	}
 	return false;
+}
+
+stock bool IsValidTeamVictory(Event hEvent)
+{
+	if (hEvent == null)
+		return false;
+
+	char sEventName[64];
+	GetEventName(hEvent, sEventName, sizeof(sEventName));
+	if (strcmp(sEventName, "round_end") != 0)
+		return false;
+
+	// Winner event Reason: 1 = Draw, 2 = T, 3 = CT
+	if (hEvent.GetInt("winner") == 1)
+		return false;
+
+	return true;
 }


### PR DESCRIPTION
Usage:
- Used in round end event handlers to validate competitive round outcomes
- Returns true only when:
  1. The event is a valid "round_end" event
  2. A team (T or CT) has won the round (winner value 2 or 3)
- Returns false when:
  1. The event is null or not a "round_end" event
  2. The round ended in a draw (winner value 1)

Details:
- Parameter: Event hEvent - The game event to validate
- Return: bool - True if the round ended with a team victory, false otherwise

Use case: 
- Prevents duplicate round_end event processing
- Ensures plugins only react to legitimate team victories (T or CT wins)
- Helps avoid race conditions and unintended behavior in plugins that hook round_end events

Example Usage:

```sp
public void Event_RoundEnd(Event event, const char[] name, bool dontBroadcast)
{
	if (!IsTeamVictoryRound(event))
		return;

	// Your round end logic here
}
```